### PR TITLE
Feat: create a reporting for exception

### DIFF
--- a/resources/views/errors/exception-blank.blade.php
+++ b/resources/views/errors/exception-blank.blade.php
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Obelaw - Exception</title>
+    <!-- CSS files -->
+    <link rel="stylesheet" href="https://preview.tabler.io/dist/css/tabler.min.css?1695847769">
+
+    @livewireStyles
+
+    <style>
+        @import url('https://rsms.me/inter/inter.css');
+
+        :root {
+            --tblr-font-sans-serif: 'Inter Var', -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, sans-serif;
+        }
+
+        body {
+            font-feature-settings: "cv03", "cv04", "cv11";
+        }
+    </style>
+</head>
+
+<body class=" border-top-wide border-primary d-flex flex-column">
+    <div class="page page-center">
+        <div class="container-tight py-4">
+            <div class="empty">
+                <img width="199px" height="auto" class="mb-5"
+                    src="{{ asset('/vendor/obelaw/images/logo-dark.svg') }}" alt="">
+                <div class="empty-header">Code: #{{ $code }}</div>
+                <p class="empty-title">Oops… Exception</p>
+                <p class="empty-subtitle text-muted">
+                    {{ $message }}
+                </p>
+                <div class="empty-action">
+                    <a href="{{ route('obelaw.home') }}" class="btn btn-primary">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-home" width="24"
+                            height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                            stroke-linecap="round" stroke-linejoin="round">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                            <path d="M5 12l-2 0l9 -9l9 9l-2 0" />
+                            <path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7" />
+                            <path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6" />
+                        </svg>
+                        Go To Home
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+@livewireScripts
+
+</html>

--- a/src/Events/Reporting/SendReport.php
+++ b/src/Events/Reporting/SendReport.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Obelaw\Framework\Events\Reporting;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SendReport
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public $e,
+        public $request
+    ) {
+        //
+    }
+}

--- a/src/ObelawServiceProvider.php
+++ b/src/ObelawServiceProvider.php
@@ -16,6 +16,7 @@ use Obelaw\Framework\Livewire\Account\SettingsPage;
 use Obelaw\Framework\Livewire\Auth\LoginPage;
 use Obelaw\Framework\Livewire\Components\Account\UpdatePassword;
 use Obelaw\Framework\Pipeline\Locale\Languages;
+use Obelaw\Framework\Reporting\ExceptionReport;
 use Obelaw\Framework\Utils\Currency;
 use Obelaw\Framework\Views\Components\Amount;
 use Obelaw\Framework\Views\Components\Loading;
@@ -45,6 +46,8 @@ class ObelawServiceProvider extends ServiceProviderBase
         ]);
 
         Languages::setLanguage('ar', 'العربية');
+
+        $this->app->bind('obelaw.report', ExceptionReport::class);
     }
 
     /**

--- a/src/Reporting/ExceptionReport.php
+++ b/src/Reporting/ExceptionReport.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Obelaw\Framework\Reporting;
+
+use Obelaw\Framework\Events\Reporting\SendReport;
+
+class ExceptionReport
+{
+    public function notify($e, $request)
+    {
+        SendReport::dispatch($e, $request);
+    }
+
+    public function render($e, $request)
+    {
+        if ($e instanceof \Exception) {
+            return response()->view('obelaw::errors.exception-blank', [
+                'code' => $e->getCode(),
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}


### PR DESCRIPTION
If you need to send any exception to obelaw error via the `notify` method
```php
$this->reportable(function (Throwable $e) {
    if (app()->bound('obelaw.report')) {
        app('obelaw.report')->notify($e, app('request'));
    }
});
```
You can create a listener to listen on event `\Obelaw\Framework\Events\Reporting\SendReport::class`.

If you need to render a view for the exception, you can use the `render` method
```php
$this->renderable(function (\Exception $e, Request $request) {
    if (app()->bound('obelaw.report')) {
        return app('obelaw.report')->render($e, $request);
    }
});
```